### PR TITLE
Fix: install guide to align with name of folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ __**IMPORTANT**__ - The initial/minimum GP should NEVER be exactly 0.
 To install:
   1. Download this addon 
   2. Extract it to ../Interface/AddOns/ 
-  3. Rename the extracted folder from bcepgp-master to bcepgp
+  3. Rename the extracted folder from BCEPGP-master to BCEPGP
 
 **Note:**
 If you get an error when adding an item to override for example (such as item not found), but you're sure you've spelled it correctly, then the item likely does not exist in your cache. This is a restriction in the API, items are cached as you see them in game. After seeing this item, you should not receive this error again (unless you delete your cache). This error should not prevent any functionality.


### PR DESCRIPTION
When downloading the addon the folder is named with capital as the repo is name: "BCEPGP-master"
If renamed to "bcepgp" the addon will throw an arithmetic error when logged in.